### PR TITLE
Convert SamAccountName to lowercase in salt

### DIFF
--- a/gMSADumper.py
+++ b/gMSADumper.py
@@ -120,7 +120,7 @@ def main():
 
                     # Compute aes keys
                     password = currentPassword.decode('utf-16-le', 'replace').encode('utf-8')
-                    salt = '%shost%s.%s' % (args.domain.upper(), sam[:-1], args.domain.lower())
+                    salt = '%shost%s.%s' % (args.domain.upper(), sam[:-1].lower(), args.domain.lower())
                     aes_128_hash = hexlify(string_to_key(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, password, salt).contents)
                     aes_256_hash = hexlify(string_to_key(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value, password, salt).contents)
                     print('%s:aes256-cts-hmac-sha1-96:%s' % (sam, aes_256_hash.decode('utf-8')))


### PR DESCRIPTION
The hostname part in the salt must always be lowercase. Atm. it is derived from the 'sAMAccountName' attribute from LDAP, which preserves upper/lower case as used when the account was created.  Therefore, the tool does not generate the correct AES keys when used for accounts which are not completely lowercase